### PR TITLE
MNT: Add Georgios and Colin as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @matthewfeickert
+* @cophus @gvarnavi @matthewfeickert

--- a/README.md
+++ b/README.md
@@ -147,5 +147,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@cophus](https://github.com/cophus/)
+* [@gvarnavi](https://github.com/gvarnavi/)
 * [@matthewfeickert](https://github.com/matthewfeickert/)
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -53,4 +53,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - gvarnavi
+    - cophus
     - matthewfeickert


### PR DESCRIPTION
Add @gvarnavi and @cophus as feedstock maintainers given https://github.com/conda-forge/staged-recipes/pull/30174#issuecomment-2936538490.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
   - Not needed as maintainers are just metadata that don't affect the build at all.
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
